### PR TITLE
use config for prod builds

### DIFF
--- a/packages/docusaurus-plugin-api-extractor/src/generate-docs.ts
+++ b/packages/docusaurus-plugin-api-extractor/src/generate-docs.ts
@@ -39,9 +39,9 @@ export async function generateDocs(
   srcDir: string,
   outDir: string,
   sidebarConfig: CategoryMetadatasFile,
-  verbose: boolean,
-  force: boolean,
-  local: boolean
+  verbose = false,
+  force = false,
+  local = false
 ): Promise<void> {
   ensureDirSync(outDir);
 

--- a/packages/docusaurus-plugin-api-extractor/src/plugin.ts
+++ b/packages/docusaurus-plugin-api-extractor/src/plugin.ts
@@ -83,9 +83,9 @@ export default function pluginDocusaurus(
           config.srcDir,
           outputDir,
           config.sidebarConfig,
-          false,
-          false,
-          false
+          config.verbose,
+          config.force,
+          config.locale
         );
       }
     },


### PR DESCRIPTION
We should use the plugin config for production builds instead of hard coding
