### PR TITLE
dont publish tests

### DIFF
--- a/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/fix-published-files_2021-11-24-20-23.json
+++ b/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/fix-published-files_2021-11-24-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "docusaurus-plugin-api-extractor-markdown-documenter",
+      "comment": "remove test files from distro",
+      "type": "patch"
+    }
+  ],
+  "packageName": "docusaurus-plugin-api-extractor-markdown-documenter"
+}

--- a/common/changes/docusaurus-plugin-api-extractor/fix-published-files_2021-11-24-20-23.json
+++ b/common/changes/docusaurus-plugin-api-extractor/fix-published-files_2021-11-24-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "docusaurus-plugin-api-extractor",
+      "comment": "remove test files from distro",
+      "type": "patch"
+    }
+  ],
+  "packageName": "docusaurus-plugin-api-extractor"
+}

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/.npmignore
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/.npmignore
@@ -1,0 +1,5 @@
+/dist/**/test/
+*.test.js
+*.test.js.map
+*.test.d.ts
+*.test.d.ts.map

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/package.json
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/package.json
@@ -7,6 +7,9 @@
   "typings": "dist/index.d.ts",
   "author": "Gabriel J. Csapo <gabecsapo@gmail.com>",
   "license": "MIT",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "heft test --clean && cp ./src/*.ejs ./dist"
   },

--- a/plugin/docusaurus-plugin-api-extractor/.npmignore
+++ b/plugin/docusaurus-plugin-api-extractor/.npmignore
@@ -1,0 +1,5 @@
+/dist/**/test/
+*.test.js
+*.test.js.map
+*.test.d.ts
+*.test.d.ts.map


### PR DESCRIPTION
Since tests now sit in `src` we need to make sure we don't publish them