### PR TITLE
Add GitHub-flavored markdown support

### DIFF
--- a/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/union-types_2022-02-09-18-02.json
+++ b/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/union-types_2022-02-09-18-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "docusaurus-plugin-api-extractor-markdown-documenter",
+      "comment": "Add GitHub-flavored markdown support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "docusaurus-plugin-api-extractor-markdown-documenter"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -110,6 +110,7 @@ importers:
       prettier: ^2.4.1
       remark: ^13.0.0
       remark-frontmatter: ^3.0.0
+      remark-gfm: ~1.0.0
       typescript: ^4.4.2
       unist-util-visit: ^2.0.3
     dependencies:
@@ -125,6 +126,7 @@ importers:
       prettier: 2.4.1
       remark: 13.0.0
       remark-frontmatter: 3.0.0
+      remark-gfm: 1.0.0
       unist-util-visit: 2.0.3
     devDependencies:
       '@rushstack/eslint-config': 2.4.5_eslint@7.32.0+typescript@4.4.4
@@ -8064,6 +8066,12 @@ packages:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
     dev: false
 
+  /markdown-table/2.0.0:
+    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
+    dependencies:
+      repeat-string: 1.6.1
+    dev: false
+
   /matcher-collection/2.0.1:
     resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -8084,6 +8092,14 @@ packages:
       unist-util-visit: 2.0.3
     dev: false
 
+  /mdast-util-find-and-replace/1.1.1:
+    resolution: {integrity: sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==}
+    dependencies:
+      escape-string-regexp: 4.0.0
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
+    dev: false
+
   /mdast-util-from-markdown/0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
     dependencies:
@@ -8100,6 +8116,47 @@ packages:
     resolution: {integrity: sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==}
     dependencies:
       micromark-extension-frontmatter: 0.2.2
+    dev: false
+
+  /mdast-util-gfm-autolink-literal/0.1.3:
+    resolution: {integrity: sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==}
+    dependencies:
+      ccount: 1.1.0
+      mdast-util-find-and-replace: 1.1.1
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-strikethrough/0.2.3:
+    resolution: {integrity: sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==}
+    dependencies:
+      mdast-util-to-markdown: 0.6.5
+    dev: false
+
+  /mdast-util-gfm-table/0.1.6:
+    resolution: {integrity: sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==}
+    dependencies:
+      markdown-table: 2.0.0
+      mdast-util-to-markdown: 0.6.5
+    dev: false
+
+  /mdast-util-gfm-task-list-item/0.1.6:
+    resolution: {integrity: sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==}
+    dependencies:
+      mdast-util-to-markdown: 0.6.5
+    dev: false
+
+  /mdast-util-gfm/0.1.2:
+    resolution: {integrity: sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==}
+    dependencies:
+      mdast-util-gfm-autolink-literal: 0.1.3
+      mdast-util-gfm-strikethrough: 0.2.3
+      mdast-util-gfm-table: 0.1.6
+      mdast-util-gfm-task-list-item: 0.1.6
+      mdast-util-to-markdown: 0.6.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /mdast-util-to-hast/10.0.1:
@@ -8174,6 +8231,55 @@ packages:
     resolution: {integrity: sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==}
     dependencies:
       fault: 1.0.4
+    dev: false
+
+  /micromark-extension-gfm-autolink-literal/0.5.7:
+    resolution: {integrity: sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==}
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /micromark-extension-gfm-strikethrough/0.6.5:
+    resolution: {integrity: sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==}
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /micromark-extension-gfm-table/0.4.3:
+    resolution: {integrity: sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==}
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /micromark-extension-gfm-tagfilter/0.3.0:
+    resolution: {integrity: sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==}
+    dev: false
+
+  /micromark-extension-gfm-task-list-item/0.3.3:
+    resolution: {integrity: sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==}
+    dependencies:
+      micromark: 2.11.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /micromark-extension-gfm/0.3.3:
+    resolution: {integrity: sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==}
+    dependencies:
+      micromark: 2.11.4
+      micromark-extension-gfm-autolink-literal: 0.5.7
+      micromark-extension-gfm-strikethrough: 0.6.5
+      micromark-extension-gfm-table: 0.4.3
+      micromark-extension-gfm-tagfilter: 0.3.0
+      micromark-extension-gfm-task-list-item: 0.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /micromark/2.11.4:
@@ -9912,6 +10018,15 @@ packages:
     dependencies:
       mdast-util-frontmatter: 0.2.0
       micromark-extension-frontmatter: 0.2.2
+    dev: false
+
+  /remark-gfm/1.0.0:
+    resolution: {integrity: sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==}
+    dependencies:
+      mdast-util-gfm: 0.1.2
+      micromark-extension-gfm: 0.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /remark-mdx-remove-exports/1.6.22:

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/package.json
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/package.json
@@ -30,7 +30,8 @@
     "remark": "^13.0.0",
     "remark-frontmatter": "^3.0.0",
     "unist-util-visit": "^2.0.3",
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.0.0",
+    "remark-gfm": "~1.0.0"
   },
   "devDependencies": {
     "eslint": "^7.0.0",

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/markdown/to-docusaurus-markdown.ts
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/markdown/to-docusaurus-markdown.ts
@@ -1,4 +1,5 @@
 import remark from 'remark';
+import remarkGfm from 'remark-gfm';
 import remarkFrontmatter from 'remark-frontmatter';
 import { repairHeritageTypes } from './repair-heritage-types';
 import { emitDocusaurusFrontMatter } from './emit-docusaurus-front-matter';
@@ -13,6 +14,7 @@ import { replaceAll } from './replace-all';
 export const toDocusaurusMarkDown = (markdownString: string, id: string): string => {
   let out: string = remark()
     .use(remarkFrontmatter, ['yaml'])
+    .use(remarkGfm)
     .use(repairHeritageTypes)
     .use(repairEscaping)
     .use(emitDocusaurusFrontMatter, id)

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/to-docusaurus-markdown.test.ts.snap
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/to-docusaurus-markdown.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can support union types in a table 1`] = `
+"---
+id: myClass
+hide_title: true
+custom_edit_url: null
+---
+
+|  Property | Modifiers | Type | Description |
+|  --- | --- | --- | --- |
+|  [myProperty](./myClass.myProperty.md) |  | 'number' \\| 'string' | A property that has a union type. |
+"
+`;

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/to-docusaurus-markdown.test.ts.snap
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/to-docusaurus-markdown.test.ts.snap
@@ -7,8 +7,8 @@ hide_title: true
 custom_edit_url: null
 ---
 
-|  Property | Modifiers | Type | Description |
-|  --- | --- | --- | --- |
-|  [myProperty](./myClass.myProperty.md) |  | 'number' \\| 'string' | A property that has a union type. |
+| Property                              | Modifiers | Type                 | Description                       |
+| ------------------------------------- | --------- | -------------------- | --------------------------------- |
+| [myProperty](./myClass.myProperty.md) |           | 'number' \\\\| 'string' | A property that has a union type. |
 "
 `;

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/to-docusaurus-markdown.test.ts
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/to-docusaurus-markdown.test.ts
@@ -1,0 +1,12 @@
+import { toDocusaurusMarkDown } from '../markdown/to-docusaurus-markdown';
+
+it('can support union types in a table', () => {
+  const incoming = `
+  |  Property | Modifiers | Type | Description |
+  |  --- | --- | --- | --- |
+  |  [myProperty](./myClass.myProperty.md) |  | 'number' \\| 'string' | A property that has a union type. |
+  `;
+
+  const processedMarkdown = toDocusaurusMarkDown(incoming, 'myClass');
+  expect(processedMarkdown).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary

Allows markdown generator to be able to reason about tables, which isn't
a part of the standard Markdown spec. Resolves an issue where escaped
characters in a table would be removed, creating invalid table output.
(This is needed, for instance when a TypeScript union type is listed in
a table.)

## Testing

Added a test that initially failed, then verified that adding `remark-gfm` to `remark()` processing fixed the issue.

Also manually verified by linking to another package that was having issue with union types (e.g.: `string | number`) in tables. This had a couple hiccups (my linked package had trouble finding `mdast-util-to-markdown/lib/unsafe` but the build in this repo was ok), but I was able to manually verify that the `|` character was escaped in the Docusaurus output.

The `\\\\|` in the snapshot fixture is a little weird. I think there's some double-escaping going on, thus my double-checking that it actually worked in another repo.