### PR TITLE
Omit enum members from sidebar.

### DIFF
--- a/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/enums-sidebar_2022-02-10-19-33.json
+++ b/common/changes/docusaurus-plugin-api-extractor-markdown-documenter/enums-sidebar_2022-02-10-19-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "docusaurus-plugin-api-extractor-markdown-documenter",
+      "comment": "Omit enum members from sidebar.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "docusaurus-plugin-api-extractor-markdown-documenter"
+}

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/DocusaurusFeature.ts
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/DocusaurusFeature.ts
@@ -85,6 +85,9 @@ export function buildNavigation(
         parentNodes.push(navItem);
         buildNavigation(navItem.items, apiItem, documenter);
         break;
+      case 'EnumMember':
+        // Enum members don't have their own page, so skip them.
+        break;
       default:
         parentNodes.push({
           type: 'doc',

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/buildNavigation.test.ts.snap
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/__snapshots__/buildNavigation.test.ts.snap
@@ -99,6 +99,11 @@ Array [
         "type": "category",
       },
       Object {
+        "id": "EnumeratedType",
+        "label": "EnumeratedType",
+        "type": "doc",
+      },
+      Object {
         "id": "foo",
         "label": "foo",
         "type": "doc",

--- a/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/fixtures/api-model.json
+++ b/plugin/docusaurus-plugin-api-extractor-markdown-documenter/src/test/fixtures/api-model.json
@@ -536,6 +536,63 @@
             }
           ],
           "name": "sum"
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "example-project!EnumeratedType:enum",
+          "docComment": "/**\n * An enumerated property.\n *\n * @public\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum EnumeratedType"
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "EnumeratedType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "example-project!EnumeratedType.FOO:member",
+              "docComment": "/**\n * Foo.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FOO = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"foo\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FOO",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "example-project!EnumeratedType.BAR:member",
+              "docComment": "/**\n * Bar.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BAR = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"bar\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BAR",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
EnumMembers don't have their own page, so don't generate links for the
individual props in the sidebar.